### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.8",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import rateLimit from "express-rate-limit";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
@@ -78,8 +79,15 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
-  // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  // Apply rate limiting ONLY to the catch-all file serving route
+  const staticRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  app.use("*", staticRateLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/2](https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/2)

To properly address this issue, add a rate-limiting middleware to protect the catch-all static file handler in the `serveStatic` function. The best practice for Express servers is to use the well-known `express-rate-limit` package since it is robust and widely supported. This package is not imported in the current snippet, so you need to add the import. 

Insert a rate limiter instance just before the catch-all route:  
- Import `express-rate-limit`.  
- Create a limiter instance (e.g., 100 requests per 15 minutes per IP is common).  
- Use `app.use(limiter)` **before** the handler that does the file access (`res.sendFile(...)`).  
Minimize disruption: Do not apply the limiter globally; only apply it before the catch-all route within `serveStatic`.  

Change needed:
- Add the import near the other imports.
- Add the rate limiter definition inside `serveStatic`.
- Add `app.use(limiter)` before `app.use("*", ...)` in `serveStatic`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
