### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
   sfs:
     uses: smartflow-systems/SmartFlowSite/.github/workflows/sfs-ci-deploy.yml@main
     secrets: inherit
+    permissions:
+      contents: read
 name: CI (Reusable SFS)
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/5](https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/5)

To fix the problem, we should add a `permissions` block to the `sfs` job in `.github/workflows/ci.yml`. The block should explicitly set the job's permissions for the `GITHUB_TOKEN` as limited as possible. Unless the reusable workflow requires write access (unlikely for most CI jobs), we should prefer (`contents: read`), which allows the steps to check out code, fetch artifacts, etc., but not to push changes or perform write operations. This change should be inserted directly beneath the `uses:` and `secrets:` lines within the `sfs` job definition, following the same precedent set by the `use-reusable` job. 

#### Where to change:
- Edit `.github/workflows/ci.yml` within the `sfs` job (lines 7–10).
- Insert a `permissions:` block after `uses:` (line 8) and `secrets:` (line 9), matching indentation.
- Set `contents: read` at minimum. If you know the required permissions, you can further restrict (or expand) them.

There are no extra imports, method definitions, or dependencies required for this YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
