### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sfs-ci.yml
+++ b/.github/workflows/sfs-ci.yml
@@ -1,4 +1,6 @@
 ﻿name: SFS CI Deploy
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/3](https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/3)

To fix the issue, you should add an explicit `permissions` block under the root of your workflow file `.github/workflows/sfs-ci.yml`. This block should minimally grant `contents: read`, which is enough for most workflows that do not require additional write capabilities. If more permission is needed, you may explicitly extend the permissions as necessary. Since the exact permissions required are not specified in the snippet and the called reusable workflow may dictate what is needed, the safest minimal fix (and the one suggested by CodeQL) is to set `contents: read` at the workflow level. You need to insert the following block after the `name` declaration and before the `on:` key:

```yaml
permissions:
  contents: read
```

No other changes are required in this file per the CodeQL report.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
