### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -42,7 +42,16 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  app.use("*", async (req, res, next) => {
+
+  // Apply rate limiting to the Vite catch-all route
+  const viteRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  app.use("*", viteRateLimiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/1](https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/1)

To fix the missing rate limiting on the catch-all Vite handler, we should apply a suitable rate limiting middleware to the route defined by `app.use("*", ...)` inside `setupVite()`. This can be accomplished by using the already imported `express-rate-limit`. We will define a rate limiter instance similar to the one used in `serveStatic()`, choosing a conservative default (e.g., 100 requests per 15 minutes per IP, same as the static handler). The change must be local: add the rate limiter and insert it as middleware before the async handler at line 45.

No changes to functionality or ordering are required; simply insert a rate limiting instance as middleware before the route handler used for serving the Vite client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
