### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,4 +1,6 @@
 name: pip-audit
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/6](https://github.com/smartflow-systems/SFSAPDemoCRM/security/code-scanning/6)

To fix the problem, add a `permissions` key that explicitly restricts permissions to the lowest required for this workflow. Since this workflow installs dependencies and runs an audit, but does not require write access to repository contents, the minimal needed is usually `contents: read`. The `permissions` block can be added at the root of the workflow (top-level, just under `name`) to apply to all jobs. No other changes (steps, imports, methods) are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
